### PR TITLE
Don't burn the CPU: scaling_min_freq 300000

### DIFF
--- a/rootdir/init.yukon.pwr.rc
+++ b/rootdir/init.yukon.pwr.rc
@@ -42,7 +42,7 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpufreq/ondemand/optimal_freq 787200
     write /sys/devices/system/cpu/cpufreq/ondemand/sync_freq 300000
     write /sys/devices/system/cpu/cpufreq/ondemand/up_threshold_any_cpu_load 80
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 787200
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 300000
     chown system /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
     chown system /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
     chown system /sys/devices/system/cpu/cpu1/online


### PR DESCRIPTION
CAF (crazily) sets this to 787MHz, but at least factory
images correctly set this to 300MHz.

Signed-off-by: Adam Farden <adam@farden.cz>