### PR TITLE
Lights

### DIFF
--- a/liblights/Android.mk
+++ b/liblights/Android.mk
@@ -15,6 +15,11 @@
 LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
+
+ifeq ($(strip $(BOARD_HAS_DIM_BACKLIGHT)),true)
+LOCAL_CFLAGS += -DHAS_DIM_BACKLIGHT
+endif
+
 LOCAL_SRC_FILES := lights.c
 LOCAL_SHARED_LIBRARIES := liblog
 LOCAL_MODULE := lights.yukon

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -91,8 +91,8 @@
     <!-- Flag indicating whether the we should enable the automatic brightness in Settings. -->
     <bool name="config_automatic_brightness_available">true</bool>
 
-    <!-- Allow backlight brightness to go down to 100 -->
-    <integer name="config_screenBrightnessSettingMinimum">100</integer>
+    <!-- Allow backlight brightness to go down to 10 -->
+    <integer name="config_screenBrightnessSettingMinimum">10</integer>
 
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N  1 zones as follows:


### PR DESCRIPTION
Tianchi's backlight reacts very differently compared to seagull / eagle / flamingo

this nice hack makes tianchi's backlight work much better with AOSP, but is there a better way to do this? For now, this works fine.