### PR TITLE
Fix bluetooth initialization

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -398,9 +398,9 @@ service fuse_usbdisk /system/bin/sdcard -u 1023 -g 1023 -w 1023 -d /mnt/media_rw
 
 #BT service
 service hciattach /system/bin/sh /system/etc/init.yukon.bt.sh
-    class late_start
+    class main
     user bluetooth
-    group qcom_oncrpc bluetooth net_bt_admin system
+    group bluetooth system
     disabled
     oneshot
 

--- a/rootdir/system/etc/init.yukon.bt.sh
+++ b/rootdir/system/etc/init.yukon.bt.sh
@@ -46,12 +46,14 @@ case $POWER_CLASS in
      logi "Power Class: To override, Before turning BT ON; setprop qcom.bt.dev_power_class <1 or 2 or 3>";;
 esac
 
+echo 1 > /sys/module/hci_smd/parameters/hcismd_set
 if [$BDADDR == ""]
 then
-/system/bin/hci_qcomm_init -e $PWR_CLASS -vv
+/system/bin/hci_qcomm_init -e $PWR_CLASS -vv &
 else
-/system/bin/hci_qcomm_init --enable-clock-sharing -b $BDADDR -e $PWR_CLASS -vv
+/system/bin/hci_qcomm_init --enable-clock-sharing -b $BDADDR -e $PWR_CLASS -vv &
 fi
+echo 0 > /sys/module/hci_smd/parameters/hcismd_set
 
 case $? in
   0) logi "Bluetooth QSoC firmware download succeeded, $PWR_CLASS $BDADDR $TRANSPORT";;

--- a/rootdir/ueventd.yukon.rc
+++ b/rootdir/ueventd.yukon.rc
@@ -154,6 +154,7 @@
 /dev/hidraw*                                         0666 system  system
 /dev/ttyHS0                                          0660 bluetooth bluetooth
 /dev/ttyHS2                                          0660 bluetooth bluetooth
+/sys/module/hci_smd/parameters/hcismd_set            0660 bluetooth bluetooth
 /sys/devices/platform/msm_serial_hs.0/clock          0660 bluetooth bluetooth
 
 # wlan


### PR DESCRIPTION
It was anyway wrong and on 3.10 kernel those changes are
required for BTS402x to get initialized correctly.