### PR TITLE
mkqcdtimage: use dts from out folder

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -35,7 +35,7 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 BOARD_KERNEL_BOOTIMG := true
 BOARD_CUSTOM_MKBOOTIMG := mkqcdtbootimg
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
-BOARD_MKBOOTIMG_ARGS += --dt_dir device/sony/$(TARGET_DEVICE)/dtbs --dt_version 2
+BOARD_MKBOOTIMG_ARGS += --dt_dir out/target/product/$(TARGET_DEVICE)/dtbs --dt_version 2
 
 BOARD_KERNEL_CMDLINE := console=ttyHSL0,115200,n8 androidboot.console=ttyHSL0 androidboot.hardware=yukon user_debug=31 msm_rtb.filter=0x37 selinux=0
 


### PR DESCRIPTION
switch to out/...../dts folder to be able to use dtb files for both inline and
prebuilt kernels

Signed-off-by: Aleksi Suomalainen <suomalainen.aleksi@gmail.com>