### PR TITLE
power: Enable sched_wake_to_idle and retention on cpu1-3

### DIFF
--- a/rootdir/init.yukon.pwr.rc
+++ b/rootdir/init.yukon.pwr.rc
@@ -23,14 +23,14 @@ on property:sys.boot_completed=1
     write /sys/module/msm_pm/modes/cpu2/standalone_power_collapse/suspend_enabled 1
     write /sys/module/msm_pm/modes/cpu3/standalone_power_collapse/suspend_enabled 1
     write /sys/module/msm_pm/modes/cpu0/standalone_power_collapse/idle_enabled 1
-    write /sys/module/msm_pm/modes/cpu1/standalone_power_collapse/idle_enabled 1
-    write /sys/module/msm_pm/modes/cpu2/standalone_power_collapse/idle_enabled 1
-    write /sys/module/msm_pm/modes/cpu3/standalone_power_collapse/idle_enabled 1
+    write /sys/module/msm_pm/modes/cpu1/retention/idle_enabled 1
+    write /sys/module/msm_pm/modes/cpu2/retention/idle_enabled 1
+    write /sys/module/msm_pm/modes/cpu3/retention/idle_enabled 1
     write /sys/module/msm_pm/modes/cpu0/power_collapse/idle_enabled 1
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 1
     write /sys/devices/system/cpu/cpu3/online 1
-
+    write /proc/sys/kernel/sched_wake_to_idle 1
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "ondemand"
     write /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate 50000
     write /sys/devices/system/cpu/cpufreq/ondemand/up_threshold 90


### PR DESCRIPTION
This is needed for 3.10 kernel, where standalone_power_collapse
is almost totally broken for MSM8226 (A7 CPUs), leading to
hardlocks at runtime suspend time.

Using retention we will still save enough power, also because, if
we use an automatic hotplug mechanism, the CPUs will be suspended
and consequently power collapsed.
When the CPUs are UP and idle, we're still saving some power because
retention is a low power state where only the actual core is clock
gated, but the registers associated with the core are being retained,
hence the voltage will be retained too, but it will be reduced to a
really small value to keep the current CPU registers active.

This will also make us to resume the core faster from the idle state,
as the kernel won't have to warm-boot again to be able to resume normal
operation.