### PR TITLE
yukon: configure low memory killer manually

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -290,6 +290,11 @@ on boot
     #WCNSS enable
     write /dev/wcnss_wlan 1
 
+    # low memory killer is not calculating the minfree paremeters correctly
+    # so set them manually and prevent any changes.
+    write /sys/module/lowmemorykiller/parameters/minfree "6144,7680,9216,10752,12288,15360"
+    chmod 440 /sys/module/lowmemorykiller/parameters/minfree
+
 #SONY misc
 service ta_qmi_service /system/bin/ta_qmi_service
     class main


### PR DESCRIPTION
low memory killer is not calculating the minfree paremeters correctly,
resulting in processes being killed before boot has even completed.
Set the minfree values manually and prevent any changes.

Signed-off-by: Adam Farden <adam@farden.cz>