### PR TITLE
init.yukon.rc: Use timekeep instead of time_daemon

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -120,9 +120,6 @@ on post-fs-data
     mkdir /data/shared 0755
     chown system system /data/shared
 
-    # Create /data/time folder for time-services
-    mkdir /data/time/ 0700 system system
-
     # Enable the setgid bit on the directory
     mkdir /data/audio 0770 media audio
     chmod 2770 /data/audio
@@ -436,7 +433,7 @@ service charger /sbin/healthd -c
     critical
     seclabel u:r:healthd:s0
 
-service time_daemon /system/bin/time_daemon
+service timekeep /system/bin/timekeep restore
    class late_start
    user root
    group root


### PR DESCRIPTION
I didn't try this out yet, but it should be okay