### PR TITLE
Remove BOARD_USES_GENERIC_AUDIO

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -60,7 +60,6 @@ MAX_EGL_CACHE_SIZE := 2048*1024
 OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
 BOARD_EGL_CFG := device/sony/yukon/rootdir/system/lib/egl/egl.cfg
 
-BOARD_USES_GENERIC_AUDIO := false
 BOARD_USES_ALSA_AUDIO := true
 
 USE_CAMERA_STUB := false


### PR DESCRIPTION
BOARD_USES_GENERIC_AUDIO is commented out. And setting it to false makes no sense?
https://android.googlesource.com/platform/hardware/libhardware_legacy/+/android-5.0.2_r1/audio/Android.mk