### PR TITLE
yukon: Add tianchi_dsds support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-ifeq ($(filter-out eagle flamingo seagull tianchi,$(TARGET_DEVICE)),)
+ifeq ($(filter-out eagle flamingo seagull tianchi tianchi_dsds,$(TARGET_DEVICE)),)
 
 LOCAL_PATH := $(call my-dir)
 


### PR DESCRIPTION
Since dsds is supported in kernel side, it can be added to device tree too.