### PR TITLE
Revert "yukon: fix cmdline permission"

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -18,7 +18,7 @@ import init.yukon.dev.rc
 
 on early-init
     mount debugfs debugfs /sys/kernel/debug
-    chmod 644 /proc/cmdline
+
     mkdir /firmware 0771 system system
 
     # Set permissions for persist partition


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-yukon#48

It *should* not be world readable, as it contains the IMEI and serial number.