### PR TITLE
yukon: enable smooth streaming

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -20,6 +20,7 @@ persist.radio.mode_pref_nv10=1
 persist.radio.snapshot_enabled=1
 persist.radio.snapshot_timer=2
 ro.opengles.version=196608
+mm.enable.smoothstreaming=true
 ro.qc.sdk.audio.fluencetype=none
 persist.audio.fluence.voicecall=true
 persist.audio.fluence.voicerec=false


### PR DESCRIPTION
Streaming an embeded video in browser seems to cause high CPU
Enabling smooth streaming to relieve this.

Signed-off-by: David Viteri <davidteri91@gmail.com>