### PR TITLE
yukon: Don't use fake vsync

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -4,7 +4,6 @@ debug.mdpcomp.logs=0
 debug.sf.hw=1
 dev.pm.dyn_samplingrate=1
 persist.hwc.mdpcomp.enable=true
-debug.hwc.fakevsync=1
 persist.fuse_sdcard=true
 ril.subscription.types=NV,RUIM
 rild.libargs=-d /dev/smd0


### PR DESCRIPTION
Seems to work fine. Feels okay, vsync_event is created.

This was tested on BF64 kernel, and CAF HALs, therefore, behaviour on AOSP could be different.

Feel free to reject if there's a reason for it.