### PR TITLE
yukon: fix remote submix sampling rates

### DIFF
--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -124,7 +124,7 @@ audio_hw_modules {
   r_submix {
     outputs {
       submix {
-        sampling_rates 44100|48000
+        sampling_rates 48000
         channel_masks AUDIO_CHANNEL_OUT_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_OUT_REMOTE_SUBMIX
@@ -132,7 +132,7 @@ audio_hw_modules {
     }
     inputs {
       submix {
-        sampling_rates 44100|48000
+        sampling_rates 48000
         channel_masks AUDIO_CHANNEL_IN_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_IN_REMOTE_SUBMIX


### PR DESCRIPTION
Only list 48000 Hz in supported sampling rates
for remote submix
output and input stream profiles to avoid mismatch betwen playback
and capture

Signed-off-by: David Viteri <davidteri91@gmail.com>