### PR TITLE
yukon: copy audio_effects to correct way

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -50,7 +50,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml
 
 PRODUCT_COPY_FILES += \
-    $(SONY_ROOT)/system/etc/audio_effects.conf:system/etc/audio_effects.conf \
+    $(SONY_ROOT)/system/etc/audio_effects.conf:system/vendor/etc/audio_effects.conf \
     $(SONY_ROOT)/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
     $(SONY_ROOT)/system/etc/media_codecs.xml:system/etc/media_codecs.xml \
     $(SONY_ROOT)/system/etc/media_profiles.xml:system/etc/media_profiles.xml \


### PR DESCRIPTION
AOSP builds is ignoring our audio_effects.conf at the start of build.
Correct the paths instead of system/etc/audio_effects.conf ---> system/vendor/etc/audio_effects.conf as hammerhead
See (string 170): https://android.googlesource.com/device/lge/hammerhead/+/android-5.1.1_r1/device.mk

Signed-off-by: David Viteri <davidteri91@gmail.com>