### PR TITLE
device.mk: Don't build libgenlock

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -98,7 +98,6 @@ PRODUCT_PACKAGES += \
     copybit.msm8226 \
     hwcomposer.msm8226 \
     memtrack.msm8226 \
-    libgenlock \
     libqdutils \
     libqdMetaData
 


### PR DESCRIPTION
Removed since dinosaur age:
https://android.googlesource.com/platform/hardware/qcom/display/+/83b98f3b7c3c458707c95b854a3669c98d28d1f5
https://android.googlesource.com/platform/hardware/qcom/display/+/869ba57828f97e0b3cf8e1413b3f15248888f114