### PR TITLE
yukon: Remove deprecated egl.cfg

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -58,7 +58,6 @@ MAX_EGL_CACHE_KEY_SIZE := 12*1024
 MAX_EGL_CACHE_SIZE := 2048*1024
 OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
 NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3
-BOARD_EGL_CFG := device/sony/yukon/rootdir/system/lib/egl/egl.cfg
 
 # Audio
 BOARD_USES_ALSA_AUDIO := true

--- a/device.mk
+++ b/device.mk
@@ -39,6 +39,8 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml \
     frameworks/native/data/etc/android.hardware.location.gps.xml:system/etc/permissions/android.hardware.location.gps.xml \
     frameworks/native/data/etc/android.hardware.touchscreen.multitouch.jazzhand.xml:system/etc/permissions/android.hardware.touchscreen.multitouch.jazzhand.xml \
+    frameworks/native/data/etc/android.hardware.sensor.stepcounter.xml:system/etc/permissions/android.hardware.sensor.stepcounter.xml \
+    frameworks/native/data/etc/android.hardware.sensor.stepdetector.xml:system/etc/permissions/android.hardware.sensor.stepdetector.xml \
     frameworks/native/data/etc/android.hardware.wifi.xml:system/etc/permissions/android.hardware.wifi.xml \
     frameworks/native/data/etc/android.hardware.wifi.direct.xml:system/etc/permissions/android.hardware.wifi.direct.xml \
     frameworks/native/data/etc/android.hardware.sensor.compass.xml:system/etc/permissions/android.hardware.sensor.compass.xml \

--- a/rootdir/system/lib/egl/egl.cfg
+++ b/rootdir/system/lib/egl/egl.cfg
@@ -1,2 +1,0 @@
-0 0 android
-0 1 adreno


### PR DESCRIPTION
You can read about this here: http://www.2net.co.uk/tutorial/android-egl-cgf-is-dead

the last time was used by EGL/Loader was in jellybean: https://android.googlesource.com/platform/frameworks/native/+/jb-mr2.0.0-release/opengl/libs/EGL/Loader.cpp

From kitkat this isn't needed anymore: https://android.googlesource.com/platform/frameworks/native/+/kitkat-cts-dev/opengl/libs/EGL/Loader.cpp
so this can be removed.

Signed-off-by: David Viteri <davidteri91@gmail.com>