### PR TITLE
yukon: avoid fb2 denials

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -209,6 +209,10 @@ on boot
     chmod 0664 /sys/class/graphics/fb1/video_mode
     chmod 0664 /sys/class/graphics/fb1/hdcp/tp
 
+    # fb2 permissions
+    chown system graphics /sys/class/graphics/fb2/ad
+    chmod 0664 /sys/class/graphics/fb2/ad
+
     #For bridgemgr daemon to inform the USB driver of the correct transport
     chown radio radio /sys/class/android_usb/f_rmnet_smd_sdio/transport
 


### PR DESCRIPTION
E/qdhwcomposer(  255): void qhwc::adWrite(const int&): Failed to open /sys/class/graphics/fb2/ad with error Permission denied

Signed-off-by: David Viteri <davidteri91@gmail.com>