### PR TITLE
yukon: add missing libloc_core for gps

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -132,6 +132,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     libloc_api_v02 \
     libloc_adapter \
+    libloc_core \
     libloc_eng \
     libgps.utils \
     gps.msm8226


### PR DESCRIPTION
https://android.googlesource.com/platform/hardware/qcom/gps/+/android-5.1.1_r1/core/Android.mk

Signed-off-by: David Viteri <davidteri91@gmail.com>