### PR TITLE
yukon: init: qmux: Launch QMUXD process as root user

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -302,7 +302,7 @@ service ta_qmi_service /system/bin/ta_qmi_service
 #QCOM prop
 service qmuxd /system/bin/qmuxd
     class main
-    user radio
+    user root
     group radio audio bluetooth gps diag
 
 #QCOM prop


### PR DESCRIPTION
Launch QMUXD as root to enable it to obtain AP_BLOCK_SUSPEND
capability to acquire wakelock during suspend.

QMUXD will downgrade itself to user radio after getting the
necessary capabilities.

fix:
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_lock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_unlock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_lock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_unlock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_lock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_unlock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_lock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_unlock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_lock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]
E/QC-QMI ( 396): linux_qmi_qmux_io_wake_unlock: Err in writing wakelock=qmuxd_port_wl_0, error [1:Operation not permitted]

Signed-off-by: Humberto Borba <humberos@gmail.com>