### PR TITLE
yukon: typo: libtinymix -> tinymix

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -87,7 +87,7 @@ PRODUCT_PACKAGES += \
     libtinyalsa \
     libtinycompress \
     libaudioroute \
-    libtinymix
+    tinymix
 
 # Audio effects
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
No explanation necessary.

Signed-off-by: Adam Farden <adam@farden.cz>