### PR TITLE
yukon: qmi: stop the missing modem logspam

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -195,4 +195,5 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Platform specific default properties
 #
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-    persist.sys.usb.config=mtp
+    persist.sys.usb.config=mtp \
+    persist.data.qmi.adb_logmask=0


### PR DESCRIPTION
The 'error' messages are telling us we don't have an external radio,
but of course we have an integrated radio, so networking works fine.

The fix would be to modify the proprietary QMI code, but it's easier
to simply hide it.

**Perhaps keep this open until seagull networking is fixed.**