### PR TITLE
yukon: build libemoji.so

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -176,6 +176,9 @@ PRODUCT_PACKAGES += \
     InCallUI \
     Launcher3
 
+PRODUCT_PACKAGES += \
+    libemoji
+
 # Filesystem management tools
 PRODUCT_PACKAGES += \
     e2fsck


### PR DESCRIPTION
optional, but used by several services when present, including chromium

Signed-off-by: Adam Farden <adam@farden.cz>