### PR TITLE
Art

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -101,7 +101,9 @@ TARGET_SYSTEM_PROP := device/sony/yukon/system.prop
 EXTENDED_FONT_FOOTPRINT := true
 
 # Enable dex-preoptimization to speed up first boot sequence
-WITH_DEXPREOPT := true
+ifeq ($(HOST_OS),linux)
+    WITH_DEXPREOPT ?= true
+endif
 
 BUILD_KERNEL := true
 -include vendor/sony/kernel/KernelConfig.mk

--- a/device.mk
+++ b/device.mk
@@ -195,6 +195,21 @@ PRODUCT_COPY_FILES += device/sample/etc/apns-full-conf.xml:system/etc/apns-conf.
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qualcomm.bt.hci_transport=smd
 
+# ART
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.dex2oat-Xms=32m \
+    dalvik.vm.dex2oat-Xmx=256m \
+    dalvik.vm.image-dex2oat-Xms=48m \
+    dalvik.vm.image-dex2oat-Xmx=48m \
+    dalvik.vm.dex2oat-filter=interpret-only \
+    dalvik.vm.image-dex2oat-filter=speed
+
+# ART
+PRODUCT_DEX_PREOPT_DEFAULT_FLAGS := \
+    --compiler-filter=interpret-only
+
+$(call add-product-dex-preopt-module-config,services,--compiler-filter=speed)
+
 # Platform specific default properties
 #
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
yukon: Check host for Dalvik preoptimization
Turn ON Dalvik preoptimization if the build is running on Linux hosts
(since host Dalvik isn't built for non-Linux hosts)

-------------------------------------------------------------------------------------------
yukon: Add ART dex2oat controls
These values are present at stock version.
Also, set compiler-filter as "interpret-only" which skips all compilation
and relies on the interpreter to run code.