### PR TITLE
YUKON Update headers to reflect latest changes on 3.10 kernel

### DIFF
--- a/kernel-headers/uapi/linux/msm_mdp.h
+++ b/kernel-headers/uapi/linux/msm_mdp.h
@@ -106,6 +106,8 @@
 #endif
 
 enum {
+	NOTIFY_UPDATE_INIT,
+	NOTIFY_UPDATE_DEINIT,
 	NOTIFY_UPDATE_START,
 	NOTIFY_UPDATE_STOP,
 	NOTIFY_UPDATE_POWER_OFF,
@@ -116,6 +118,7 @@ enum {
 	NOTIFY_TYPE_SUSPEND,
 	NOTIFY_TYPE_UPDATE,
 	NOTIFY_TYPE_BL_UPDATE,
+	NOTIFY_TYPE_BL_AD_ATTEN_UPDATE,
 };
 
 enum {
@@ -163,6 +166,9 @@ enum {
 	MDP_RGBA_5551,	/*RGBA 5551*/
 	MDP_ARGB_4444,	/*ARGB 4444*/
 	MDP_RGBA_4444,	/*RGBA 4444*/
+	MDP_RGB_565_UBWC,
+	MDP_RGBA_8888_UBWC,
+	MDP_Y_CBCR_H2V2_UBWC,
 	MDP_IMGTYPE_LIMIT,
 	MDP_RGB_BORDERFILL,	/* border fill pipe */
 	MDP_FB_FORMAT = MDP_IMGTYPE2_START,    /* framebuffer format */
@@ -226,6 +232,12 @@ enum {
 #define MDP_SMP_FORCE_ALLOC		0x00200000
 #define MDP_TRANSP_NOP 0xffffffff
 #define MDP_ALPHA_NOP 0xff
+
+/*
+ * MDP_DEINTERLACE & MDP_SHARPENING Flags are not valid for MDP3
+ * so using them together for MDP_SMART_BLIT.
+ */
+#define MDP_SMART_BLIT			0xC0000000
 
 #define MDP_FB_PAGE_PROTECTION_NONCACHED         (0)
 #define MDP_FB_PAGE_PROTECTION_WRITECOMBINE      (1)
@@ -303,6 +315,7 @@ struct mdp_blit_req {
 	uint32_t flags;
 	int sharpening_strength;  /* -127 <--> 127, default 64 */
 	uint8_t color_space;
+	uint32_t fps;
 };
 
 struct mdp_blit_req_list {
@@ -532,6 +545,7 @@ enum mdss_mdp_blend_op {
 	BLEND_OP_MAX,
 };
 
+#define DECIMATED_DIMENSION(dim, deci) (((dim) + ((1 << (deci)) - 1)) >> (deci))
 #define MAX_PLANES	4
 struct mdp_scale_data {
 	uint8_t enable_pxl_ext;
@@ -774,6 +788,7 @@ enum {
 	mdp_lut_igc,
 	mdp_lut_pgc,
 	mdp_lut_hist,
+	mdp_lut_rgb,
 	mdp_lut_max,
 };
 
@@ -794,6 +809,20 @@ struct mdp_pgc_lut_data {
 	struct mdp_ar_gc_lut_data *b_data;
 };
 
+/*
+ * mdp_rgb_lut_data is used to provide parameters for configuring the
+ * generic RGB lut in case of gamma correction or other LUT updation usecases
+ */
+struct mdp_rgb_lut_data {
+	uint32_t flags;
+	uint32_t lut_type;
+	struct fb_cmap cmap;
+};
+
+enum {
+	mdp_rgb_lut_gc,
+	mdp_rgb_lut_hist,
+};
 
 struct mdp_lut_cfg_data {
 	uint32_t lut_type;
@@ -801,6 +830,7 @@ struct mdp_lut_cfg_data {
 		struct mdp_igc_lut_data igc_lut_data;
 		struct mdp_pgc_lut_data pgc_lut_data;
 		struct mdp_hist_lut_data hist_lut_data;
+		struct mdp_rgb_lut_data rgb_lut_data;
 	} data;
 };
 

--- a/kernel-headers/uapi/video/msm_hdmi_modes.h
+++ b/kernel-headers/uapi/video/msm_hdmi_modes.h
@@ -11,6 +11,14 @@ enum aspect_ratio {
 	HDMI_RES_AR_MAX,
 };
 
+enum msm_hdmi_s3d_mode {
+	HDMI_S3D_NONE,
+	HDMI_S3D_SIDE_BY_SIDE,
+	HDMI_S3D_TOP_AND_BOTTOM,
+	HDMI_S3D_FRAME_PACKING,
+	HDMI_S3D_MAX,
+};
+
 struct msm_hdmi_mode_timing_info {
 	uint32_t	video_format;
 	uint32_t	active_h;
@@ -31,6 +39,8 @@ struct msm_hdmi_mode_timing_info {
 	uint32_t	supported;
 	enum aspect_ratio ar;
 };
+
+#define MSM_HDMI_INIT_RES_PAGE          1
 
 #define MSM_HDMI_MODES_CEA		(1 << 0)
 #define MSM_HDMI_MODES_XTND		(1 << 1)
@@ -172,7 +182,19 @@ struct msm_hdmi_mode_timing_info {
 #define HDMI_VFRMT_1920x1200p60_16_10	ETIII_OFF(8)
 #define ETIII_VFRMT_END			HDMI_VFRMT_1920x1200p60_16_10
 
-#define HDMI_VFRMT_MAX			(ETIII_VFRMT_END + 1)
+#define RESERVE_OFF(x)			(ETIII_VFRMT_END + x)
+
+#define HDMI_VFRMT_RESERVE1		RESERVE_OFF(1)
+#define HDMI_VFRMT_RESERVE2		RESERVE_OFF(2)
+#define HDMI_VFRMT_RESERVE3		RESERVE_OFF(3)
+#define HDMI_VFRMT_RESERVE4		RESERVE_OFF(4)
+#define HDMI_VFRMT_RESERVE5		RESERVE_OFF(5)
+#define HDMI_VFRMT_RESERVE6		RESERVE_OFF(6)
+#define HDMI_VFRMT_RESERVE7		RESERVE_OFF(7)
+#define HDMI_VFRMT_RESERVE8		RESERVE_OFF(8)
+#define RESERVE_VFRMT_END		HDMI_VFRMT_RESERVE8
+
+#define HDMI_VFRMT_MAX			(RESERVE_VFRMT_END + 1)
 #define HDMI_VFRMT_FORCE_32BIT		0x7FFFFFFF
 
 /* Timing information for supported modes */
@@ -381,5 +403,10 @@ do {	\
 			HDMI_VFRMT_1280x800p60_16_10);	\
 	}	\
 } while (0)
+
+#define MSM_HDMI_MODES_GET_DETAILS(mode, MODE) do {		\
+	struct msm_hdmi_mode_timing_info info = MODE##_TIMING;	\
+	*mode = info;						\
+	} while (0)
 
 #endif /* _UAPI_MSM_HDMI_MODES_H__ */


### PR DESCRIPTION
As subject, there were some changes in the kernel and the
headers needs to be updated.

Updated headers:
* uapi/linux/msm_mdp.h
* uapi/video/msm_hdmi_modes.h