### PR TITLE
sepolicy: update for blobs moved to /vendor/bin

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -362,7 +362,7 @@ service thermanager /system/bin/thermanager /system/etc/thermanager.xml
     group root
 
 #WCNSS service
-service wcnss-service /system/vendor/bin/wcnss_service
+service wcnss_service /system/vendor/bin/wcnss_service
     class late_start
     user system
     group system wifi

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -18,4 +18,12 @@
 /system/vendor/bin/tad_static                 u:object_r:tad_exec:s0
 /system/vendor/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
 
+# QCOM Blobs moved from /system/bin to /system/vendor/bin
+/system/vendor/bin/irsc_util                  u:object_r:irsc_util_exec:s0
+/system/vendor/bin/netmgrd                    u:object_r:netmgrd_exec:s0
+/system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
+/system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0
+/system/vendor/bin/sensors.qcom               u:object_r:sensors_exec:s0
+/system/vendor/bin/wcnss_service              u:object_r:wcnss_service_exec:s0
+
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0


### PR DESCRIPTION
Also fix wcnss_service

Signed-off-by: Adam Farden <adam@farden.cz>