### PR TITLE
yukon: remove HEVC

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -118,7 +118,6 @@ PRODUCT_PACKAGES += \
     libOmxCore \
     libmm-omxcore \
     libOmxVdec \
-    libOmxVdecHevc \
     libOmxVenc
 
 #lights


### PR DESCRIPTION
that seems to be provided by manufacturers due to it isn't compiled from aosp

Signed-off-by: David Viteri <davidteri91@gmail.com>