### PR TITLE
update PN54x compatibility symlinks

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -117,7 +117,8 @@ on post-fs-data
     mkdir /data/misc/location/xtwifi 0770 gps gps
 
     # HAL is hardwired to look at pn544
-    symlink /dev/pn547 /dev/pn544
+    symlink /dev/pn54x /dev/pn544
+    symlink /dev/pn54x /dev/pn547
 
     # Create directory from IMS services
     mkdir /data/shared 0755

--- a/rootdir/ueventd.yukon.rc
+++ b/rootdir/ueventd.yukon.rc
@@ -98,6 +98,7 @@
 /dev/nfc-nci              0660   nfc        nfc
 /dev/pn544                0660   nfc        nfc
 /dev/pn547                0660   nfc        nfc
+/dev/pn54x                0660   nfc        nfc
 
 # LED
 /sys/devices/00-qcom,leds-a100/leds/led:* max_brightness 0664 system system


### PR DESCRIPTION
new NFC HAL uses generic /dev/pn54x while old one uses /dev/pn547
this change enshures compatibility for both cases

Change-Id: I073d417f220d44e5f37603310fef4782cc28f786
Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>