### PR TITLE
yukon: build copybit

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -99,6 +99,7 @@ PRODUCT_PACKAGES += \
 
 #GFX
 PRODUCT_PACKAGES += \
+    copybit.msm8226 \
     gralloc.msm8226 \
     hwcomposer.msm8226 \
     memtrack.msm8226 \


### PR DESCRIPTION
on start of the system I can see a log saying:

E/qdhwcomposer (283): FATAL ERROR: copybit hw module not found --> avoid it building from source

Signed-off-by: David Viteri <davidteri91@gmail.com>