### PR TITLE
Revert "yukon: use proper black conceal color for our kernel 3.10"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -70,6 +70,3 @@ persist.sys.wfd.virtual=0
 
 # Wi-Fi interface name
 wifi.interface=wlan0
-
-# Conceal color
-persist.vidc.dec.conceal_color=32784


### PR DESCRIPTION
This reverts commit 13d994af115ce9c387c27545a611b84cd005da65.

see: https://android.googlesource.com/platform/hardware/qcom/media/+/android-6.0.0_r1/mm-video-v4l2/vidc/vdec/src/omx_vdec_msm8974.cpp#132

Conflicts:
	system.prop