### PR TITLE
yukon: remove double packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -176,19 +176,11 @@ PRODUCT_PACKAGES += \
     charger_res_images
 
 PRODUCT_PACKAGES += \
-    librs_jni \
-    com.android.future.usb.accessory
-
-PRODUCT_PACKAGES += \
     InCallUI \
     Launcher3
 
 PRODUCT_PACKAGES += \
     libemoji
-
-# Filesystem management tools
-PRODUCT_PACKAGES += \
-    e2fsck
 
 # BoringSSL hacks
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
those already defined by aosp

librs_jni --> https://android.googlesource.com/platform/build/+/android-6.0.0_r1/target/product/generic_no_telephony.mk#39

com.android.future.usb.accessory --> https://android.googlesource.com/platform/build/+/android-6.0.0_r1/target/product/core_minimal.mk#36

e2fsck --> https://android.googlesource.com/platform/build/+/android-6.0.0_r1/target/product/core_minimal.mk#70 and https://android.googlesource.com/platform/build/+/android-6.0.0_r1/target/product/core_minimal.mk#107

Signed-off-by: David Viteri <davidteri91@gmail.com>