### PR TITLE
yukon: remove double packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -180,19 +180,11 @@ PRODUCT_PACKAGES += \
     charger_res_images
 
 PRODUCT_PACKAGES += \
-    librs_jni \
-    com.android.future.usb.accessory
-
-PRODUCT_PACKAGES += \
     InCallUI \
     Launcher3
 
 PRODUCT_PACKAGES += \
     libemoji
-
-# Filesystem management tools
-PRODUCT_PACKAGES += \
-    e2fsck
 
 # APN list
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
those already defined by aosp

librs_jni --> https://android.googlesource.com/platform/build/+/android-5.1.1_r24/target/product/generic_no_telephony.mk#38

com.android.future.usb.accessory --> https://android.googlesource.com/platform/build/+/android-5.1.1_r24/target/product/core_minimal.mk#35

e2fsck --> https://android.googlesource.com/platform/build/+/android-5.1.1_r24/target/product/core_minimal.mk#66

Signed-off-by: David Viteri <davidteri91@gmail.com>