### PR TITLE
yukon: nfc_nci hal name change

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -128,7 +128,7 @@ PRODUCT_PACKAGES += \
     com.android.nfc_extras \
     NfcNci \
     Tag \
-    nfc_nci.msm8226
+    nfc_nci.$(TARGET_DEVICE)
 
 # GPS
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
The hal name is now set to nfc_nci.$(TARGET_DEVICE)
https://android.googlesource.com/platform/external/libnfc-nci/+/android-6.0.0_r1/halimpl/pn54x/Android.mk#28