### PR TITLE
yukon: Add charge only USB mode

### DIFF
--- a/rootdir/init.yukon.usb.rc
+++ b/rootdir/init.yukon.usb.rc
@@ -83,3 +83,12 @@ on property:sys.usb.config=ptp,adb
     write /sys/class/android_usb/android0/enable 1
     start adbd
     setprop sys.usb.state ${sys.usb.config}
+
+on property:sys.usb.config=charging
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/idVendor 0FCE
+    write /sys/class/android_usb/android0/idProduct 3${ro.usb.pid_suffix}
+    write /sys/class/android_usb/android0/functions ${sys.usb.config}
+    write /sys/class/android_usb/android0/enable 1
+    stop adb
+    setprop sys.usb.state ${sys.usb.config}


### PR DESCRIPTION
under developer options there is an option where user can choice about USB connection state one of these is charging mode only
which let's to charge the phone without enable adb services

Signed-off-by: David Viteri <davidteri91@gmail.com>