### PR TITLE
yukon: Fix dynamic linker for boringssl-compat

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -29,7 +29,7 @@ on init
     symlink /system/vendor/lib/egl /egl
 
     # BoringSSL hacks
-    export LD_PRELOAD "/system/lib/libboringssl-compat.so"
+    export LD_PRELOAD "libboringssl-compat.so"
 
     mkdir /dev/bus 0755 root root
     mkdir /dev/bus/usb 0755 root root


### PR DESCRIPTION
Remove full arch path and call only lib name then the system
will preload it correctly.

Signed-off-by: Humberto Borba <humberos@gmail.com>