### PR TITLE
yukon: update file_context

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -2,6 +2,7 @@
 /dev/socket/tad                        u:object_r:tad_socket:s0
 
 /dev/pn547                             u:object_r:nfc_device:s0
+/dev/pn54x                             u:object_r:nfc_device:s0
 
 # Block devices
 /dev/block/platform/msm_sdcc\.1/by-name/modemst1          u:object_r:modem_efs_partition_device:s0
@@ -17,13 +18,5 @@
 /system/vendor/bin/sct_service                u:object_r:sct_exec:s0
 /system/vendor/bin/tad_static                 u:object_r:tad_exec:s0
 /system/vendor/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
-
-# QCOM Blobs moved from /system/bin to /system/vendor/bin
-/system/vendor/bin/irsc_util                  u:object_r:irsc_util_exec:s0
-/system/vendor/bin/netmgrd                    u:object_r:netmgrd_exec:s0
-/system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
-/system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0
-/system/vendor/bin/sensors.qcom               u:object_r:sensors_exec:s0
-/system/vendor/bin/wcnss_service              u:object_r:wcnss_service_exec:s0
 
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0


### PR DESCRIPTION
remove double paths (those are defined now on device-qcom-sepolicy l-mr1)
also add pn54x generic nfc

Signed-off-by: David Viteri <davidteri91@gmail.com>