### PR TITLE
sepolicy: update for blobs moved to /vendor/bin

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -20,6 +20,7 @@
 
 # QCOM Blobs moved from /system/bin to /system/vendor/bin
 /system/vendor/bin/irsc_util                  u:object_r:irsc_util_exec:s0
+/system/vendor/bin/mm-qcamera-daemon          u:object_r:mm-qcamerad_exec:s0
 /system/vendor/bin/netmgrd                    u:object_r:netmgrd_exec:s0
 /system/vendor/bin/qmuxd                      u:object_r:qmuxd_exec:s0
 /system/vendor/bin/rmt_storage                u:object_r:rmt_storage_exec:s0


### PR DESCRIPTION
Keep these here in case a project needs its own customized qcom/sepolicy

Signed-off-by: Adam Farden <adam@farden.cz>