### PR TITLE
yukon: Beautify and mainstream SONY_ROOT

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SONY_ROOT:=device/sony/yukon/rootdir
+SONY_ROOT = device/sony/yukon/rootdir
 
 SOMC_PLATFORM := yukon
 


### PR DESCRIPTION
- Add missing spaces not fixed on cff365a06df6693db725c5c8b0f6d3a6b2eb90a4.
- Expanding the variable on declaration time is trivial here, let's just follow the pattern of the other families.