### PR TITLE
Fix (again) the 'wcnss_service' service name

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -362,7 +362,7 @@ service thermanager /system/bin/thermanager /system/etc/thermanager.xml
     group root
 
 # WCNSS service
-service wcnss-service /system/vendor/bin/wcnss_service
+service wcnss_service /system/vendor/bin/wcnss_service
     class late_start
     user system
     group system wifi


### PR DESCRIPTION
This is the correct name of the service, as necessitated by qcom/sepolicy
https://github.com/sonyxperiadev/device-qcom-sepolicy/blob/master/common/wcnss_service.te

I had already fixed this when creating initial platform sepolicy
https://github.com/sonyxperiadev/device-sony-yukon/commit/8266751278d507d88fd4afc4857fc332adddd3ab

But the fix got blown away in a 'clean up' of comments and whitespaces.
https://github.com/sonyxperiadev/device-sony-yukon/commit/c56294c0211394f44102e87100a9ed14dd65b525

Without this name the service has no sepolicy and so cannot function when in enforcing mode.

Signed-off-by: Adam Farden <adam@farden.cz>