### PR TITLE
yukon: fix service typo

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -313,7 +313,7 @@ service thermanager /system/bin/thermanager /system/etc/thermanager.xml
     group root
 
 # WCNSS service
-service wcnss-service /system/vendor/bin/wcnss_service
+service wcnss_service /system/vendor/bin/wcnss_service
     class late_start
     user system
     group system wifi


### PR DESCRIPTION
look: https://github.com/sonyxperiadev/device-qcom-sepolicy/blob/master/common/wcnss_service.te

Signed-off-by: David Viteri <davidteri91@gmail.com>

Conflicts:
	rootdir/init.yukon.rc