### PR TITLE
Revert "yukon: configure low memory killer manually"

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -257,11 +257,6 @@ on boot
     # WCNSS enable
     write /dev/wcnss_wlan 1
 
-    # Low memory killer is not calculating the minfree paremeters correctly
-    # So set them manually and prevent any changes.
-    write /sys/module/lowmemorykiller/parameters/minfree "6144,7680,9216,10752,12288,15360"
-    chmod 440 /sys/module/lowmemorykiller/parameters/minfree
-
 # SONY misc
 service tad_static /system/vendor/bin/tad_static /dev/block/platform/msm_sdcc.1/by-name/TA 0,16
     user root


### PR DESCRIPTION
LMK on 1.2.2 kernel is now working fine. In fact these forced
settings are now causing performance problems, as RAM usage
will hit 100% but LMK will not kill any tasks.

This reverts commit e0776c687d23522664cf1a3915ca09ba4031b862.