### PR TITLE
yukon: remove vendor products

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -151,23 +151,12 @@ PRODUCT_PACKAGES += \
     libqomx_core \
     camera.msm8226
 
-# Misc
-PRODUCT_PACKAGES += \
-    libmiscta \
-    libta \
-    tad_static \
-    ta_qmi_service \
-    ta2bin
-
 # OSS
 PRODUCT_PACKAGES += \
     timekeep \
     TimeKeep \
     thermanager \
     macaddrsetup
-
-PRODUCT_PACKAGES += \
-    rmt_storage
 
 # Charger
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
those are defined at qcom-vendor.mk in vendor files

Signed-off-by: David Viteri <davidteri91@gmail.com>