### PR TITLE
yukon: add init.te

### DIFF
--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,0 +1,1 @@
+allow init wcnss_device:chr_file { write };


### PR DESCRIPTION
Avoid

[   10.530386] type=1400 audit(2390896.719:6): avc: denied { write } for pid=1 comm="init" name="wcnss_wlan" dev="tmpfs" ino=7375 scontext=u:r:init:s0 tcontext=u:object_r:wcnss_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>