### PR TITLE
yukon: init: Use predefined readahead values from kernel

### DIFF
--- a/rootdir/init.yukon.rc
+++ b/rootdir/init.yukon.rc
@@ -128,10 +128,6 @@ on early-boot
     setrlimit 8 67108864 67108864
 
 on boot
-    # Read ahead buffer
-    write /sys/block/mmcblk0/queue/read_ahead_kb 512
-    write /sys/block/mmcblk1/queue/read_ahead_kb 512
-
     # Enable writing to led blink node from userspace
     chown system system /sys/class/leds/red/blink
     chown system system /sys/class/leds/green/blink


### PR DESCRIPTION
readahead values:
sonyxperiadev/kernel@02246ee

Signed-off-by: Humberto Borba <humberos@gmail.com>