### PR TITLE
Yukon: Build Stk

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -71,6 +71,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     camera.msm8226
 
+# SimToolKit
+PRODUCT_PACKAGES += \
+    Stk
+
 # Bluetooth
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qualcomm.bt.hci_transport=smd


### PR DESCRIPTION
Build Stk

there is not windy device in yukon family so it can be defined in yukon-common

Signed-off-by: David Viteri <davidteri91@gmail.com>