### PR TITLE
yukon: remove rild.libargs

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -83,7 +83,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/vendor/lib/libril-qc-qmi-1.so \
-    rild.libargs=-d /dev/smd0 \
     ril.subscription.types=NV,RUIM
 
 # system prop for opengles version


### PR DESCRIPTION
As discussed, it is not needed, and doesnt work anyway, as spaces in
overrides do not work and results into the build.prop entry being:

rild.libargs=-d
/dev/smd0