### PR TITLE
Do not keep the LCD backlight always on

### DIFF
--- a/rootdir/init.yukon.pwr.rc
+++ b/rootdir/init.yukon.pwr.rc
@@ -68,6 +68,12 @@ on boot
     write /sys/devices/system/cpu/cpu2/online 1
     write /sys/devices/system/cpu/cpu3/online 1
 
+    # Do not keep the LCD backlight always on (causing unneeded battery
+    # power consumption):
+    write /sys/class/leds/lcd-backlight/trigger "none"
+    write /sys/class/leds/lcd-backlight/brightness 255
+    write /sys/class/leds/lcd-backlight/max_brightness 255
+
 on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor "interactive"


### PR DESCRIPTION
This change (ported from kk_mr2 branch) avoids to keep the LCD backlight always on causing a massive battery drain.